### PR TITLE
Add Goerli test net and Nodesmith provider

### DIFF
--- a/web3swift.xcodeproj/project.pbxproj
+++ b/web3swift.xcodeproj/project.pbxproj
@@ -218,6 +218,9 @@
 		E2F8083021CB096D00B6BF15 /* Web3+ERC721x.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F8082F21CB096D00B6BF15 /* Web3+ERC721x.swift */; };
 		E2F8083321CB0EF300B6BF15 /* Web3+ERC1155.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F8083221CB0EF300B6BF15 /* Web3+ERC1155.swift */; };
 		E2F8083621CB142000B6BF15 /* Web3+ERC1376.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F8083521CB142000B6BF15 /* Web3+ERC1376.swift */; };
+		ECC63DA722498544000798BF /* Web3+Nodesmith.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC63DA622498544000798BF /* Web3+Nodesmith.swift */; };
+		ECC63DA822498564000798BF /* Web3+Nodesmith.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC63DA622498544000798BF /* Web3+Nodesmith.swift */; };
+		ECC63DAB224988ED000798BF /* web3siwft_nodesmith_Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECC63DA9224988E4000798BF /* web3siwft_nodesmith_Tests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -395,6 +398,8 @@
 		E2F8082F21CB096D00B6BF15 /* Web3+ERC721x.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Web3+ERC721x.swift"; sourceTree = "<group>"; };
 		E2F8083221CB0EF300B6BF15 /* Web3+ERC1155.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Web3+ERC1155.swift"; sourceTree = "<group>"; };
 		E2F8083521CB142000B6BF15 /* Web3+ERC1376.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Web3+ERC1376.swift"; sourceTree = "<group>"; };
+		ECC63DA622498544000798BF /* Web3+Nodesmith.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Web3+Nodesmith.swift"; sourceTree = "<group>"; };
+		ECC63DA9224988E4000798BF /* web3siwft_nodesmith_Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = web3siwft_nodesmith_Tests.swift; sourceTree = "<group>"; };
 		FB43EC035C593F9E5A3644B6 /* Pods-web3swift-macOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-web3swift-macOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-web3swift-macOS/Pods-web3swift-macOS.debug.xcconfig"; sourceTree = "<group>"; };
 		FC1E6C115639177F2629E42A /* Pods_web3swift_osx.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_web3swift_osx.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -506,6 +511,7 @@
 				E23B5ADC20EA685D00DC7F32 /* web3swift_EIP67_Tests.swift */,
 				E23B5AE020EA695400DC7F32 /* web3swift_rinkeby_personalSignature_Tests.swift */,
 				E23B5AE220EA69B900DC7F32 /* web3swift_numberFormattingUtil_Tests.swift */,
+				ECC63DA9224988E4000798BF /* web3siwft_nodesmith_Tests.swift */,
 			);
 			path = web3swiftTests;
 			sourceTree = "<group>";
@@ -726,6 +732,7 @@
 				81909D1121862D17007D2AE5 /* Web3+ReadingTransaction.swift */,
 				81909D1421862D37007D2AE5 /* Web3+MutatingTransaction.swift */,
 				81909D1721862D5A007D2AE5 /* Web3+Eventloop.swift */,
+				ECC63DA622498544000798BF /* Web3+Nodesmith.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1246,6 +1253,7 @@
 				81C5DA2E2074EBF500424CD6 /* EthereumContract.swift in Sources */,
 				810B0F9E1FEC5B9C00CF0DA2 /* Web3+Eth.swift in Sources */,
 				81531AA01FE7C07A002192CC /* EthereumKeystoreV3.swift in Sources */,
+				ECC63DA722498544000798BF /* Web3+Nodesmith.swift in Sources */,
 				81A1824820D7DDA20016741F /* Promise+Web3+Personal+Sign.swift in Sources */,
 				8123E1C9200CBAF800B6D3AB /* Data+Extension.swift in Sources */,
 				817EBB23200649E000E02EAA /* RIPEMD160+StackOveflow.swift in Sources */,
@@ -1297,6 +1305,7 @@
 				00E5FE8220EA3FF40030E0D6 /* web3swift_infura_Tests.swift in Sources */,
 				81909D2A21885067007D2AE5 /* web3swift_rinkeby_personalSignature_Tests.swift in Sources */,
 				81909D2821884FF8007D2AE5 /* web3swift_remoteParsing_Tests.swift in Sources */,
+				ECC63DAB224988ED000798BF /* web3siwft_nodesmith_Tests.swift in Sources */,
 				81909D2721884FA4007D2AE5 /* web3swift_Tests.swift in Sources */,
 				81909D252188494C007D2AE5 /* web3swift_keystores_Tests.swift in Sources */,
 				81909D2621884968007D2AE5 /* web3swift_promises_Tests.swift in Sources */,
@@ -1370,6 +1379,7 @@
 				41948132203630530065A83B /* BIP32HDNode.swift in Sources */,
 				81A7B2522143C3A8004CD2C7 /* NameHash.swift in Sources */,
 				81ED4EA92190D922003E932E /* NonceMiddleware.swift in Sources */,
+				ECC63DA822498564000798BF /* Web3+Nodesmith.swift in Sources */,
 				81A1824920D7DDA20016741F /* Promise+Web3+Personal+Sign.swift in Sources */,
 				81A1822620D678590016741F /* Promise+Web3+Eth+GetGasPrice.swift in Sources */,
 				81909D1621862D37007D2AE5 /* Web3+MutatingTransaction.swift in Sources */,

--- a/web3swift/Web3/Classes/Web3+Nodesmith.swift
+++ b/web3swift/Web3/Classes/Web3+Nodesmith.swift
@@ -1,0 +1,16 @@
+//  web3swift
+//
+//  Created by Alex Vlasov.
+//  Copyright © 2018 Alex Vlasov. All rights reserved.
+//
+
+import Foundation
+
+/// Custom Web3 HTTP provider of Nodesmith nodes.
+public final class NodesmithProvider: Web3HttpProvider {
+    public init?(_ network:Networks, apiKey: String, keystoreManager manager: KeystoreManager? = nil) {
+        let nodesmithEndpoint = "https://ethereum.api.nodesmith.io/v1/\(network.name)/jsonrpc?apiKey=\(apiKey)"
+        let providerURL = URL(string: nodesmithEndpoint)
+        super.init(providerURL!, network: network, keystoreManager: manager)
+    }
+}

--- a/web3swift/Web3/Classes/Web3+Protocols.swift
+++ b/web3swift/Web3/Classes/Web3+Protocols.swift
@@ -36,6 +36,7 @@ public enum Networks {
     case Mainnet
     case Ropsten
     case Kovan
+    case Goerli
     case Custom(networkID: BigUInt)
     
     public var name: String {
@@ -44,6 +45,7 @@ public enum Networks {
         case .Ropsten: return "ropsten"
         case .Mainnet: return "mainnet"
         case .Kovan: return "kovan"
+        case .Goerli: return "goerli"
         case .Custom: return ""
         }
     }
@@ -55,10 +57,11 @@ public enum Networks {
         case .Ropsten: return BigUInt(3)
         case .Rinkeby: return BigUInt(4)
         case .Kovan: return BigUInt(42)
+        case .Goerli: return BigUInt(5)
         }
     }
     
-    static let allValues = [Mainnet, Ropsten, Kovan, Rinkeby]
+    static let allValues = [Mainnet, Ropsten, Kovan, Rinkeby, Goerli]
     
     static func fromInt(_ networkID:Int) -> Networks? {
         switch networkID {
@@ -70,6 +73,8 @@ public enum Networks {
             return Networks.Rinkeby
         case 42:
             return Networks.Kovan
+        case 5:
+            return Networks.Goerli
         default:
             return Networks.Custom(networkID: BigUInt(networkID))
         }

--- a/web3swift/Web3/Classes/Web3.swift
+++ b/web3swift/Web3/Classes/Web3.swift
@@ -74,6 +74,30 @@ public struct Web3 {
         return web3(provider: infura)
     }
     
+    // Initialized Web3 instance bound to Nodesmith's mainnet nodes.
+    public static func NodesmithMainnetWeb3(apiKey: String) -> web3 {
+        return web3(provider: NodesmithProvider(Networks.Mainnet, apiKey: apiKey)!)
+    }
+    
+    // Initialized Web3 instance bound to Nodesmith's kovan nodes.
+    public static func NodesmithKovanWeb3(apiKey: String) -> web3 {
+        return web3(provider: NodesmithProvider(Networks.Kovan, apiKey: apiKey)!)
+    }
+    
+    // Initialized Web3 instance bound to Nodesmith's goerli nodes.
+    public static func NodesmithGoerliWeb3(apiKey: String) -> web3 {
+        return web3(provider: NodesmithProvider(Networks.Goerli, apiKey: apiKey)!)
+    }
+    
+    // Initialized Web3 instance bound to Nodesmith's rinkeby nodes.
+    public static func NodesmithRinkebyWeb3(apiKey: String) -> web3 {
+        return web3(provider: NodesmithProvider(Networks.Rinkeby, apiKey: apiKey)!)
+    }
+    
+    // Initialized Web3 instance bound to Nodesmith's ropsten nodes.
+    public static func NodesmithRopstenWeb3(apiKey: String) -> web3 {
+        return web3(provider: NodesmithProvider(Networks.Ropsten, apiKey: apiKey)!)
+    }
 }
 
 struct ResultUnwrapper {

--- a/web3swift/Web3/Classes/Web3.swift
+++ b/web3swift/Web3/Classes/Web3.swift
@@ -46,7 +46,7 @@ public enum Web3Error: Error {
 }
 
 /// An arbitary Web3 object. Is used only to construct provider bound fully functional object by either supplying provider URL
-/// or using pre-coded Infura nodes
+/// or using pre-coded Infura or Nodesmith nodes
 public struct Web3 {
     
     /// Initialized provider-bound Web3 instance using a provider's URL. Under the hood it performs a synchronous call to get

--- a/web3swiftTests/web3siwft_nodesmith_Tests.swift
+++ b/web3swiftTests/web3siwft_nodesmith_Tests.swift
@@ -1,0 +1,75 @@
+//  web3swift
+//
+//  Created by Alex Vlasov.
+//  Copyright © 2018 Alex Vlasov. All rights reserved.
+//
+
+import XCTest
+import EthereumAddress
+
+@testable import web3swift_iOS
+
+class web3swift_nodesmith_Tests: XCTestCase {
+    
+    // Special API key for these integration tests
+    let API_KEY = "WEB3_SWIFT_TESTS";
+    
+    func testGetBalance() {
+        do {
+            let web3 = Web3.NodesmithMainnetWeb3(apiKey: API_KEY)
+            let address = EthereumAddress("0xe22b8979739D724343bd002F9f432F5990879901")!
+            let balance = try web3.eth.getBalance(address: address)
+            XCTAssert(balance >= 0)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testGetBlockByHash() {
+        do {
+            let web3 = Web3.NodesmithMainnetWeb3(apiKey: API_KEY)
+            let result = try web3.eth.getBlockByHash("0x6d05ba24da6b7a1af22dc6cc2a1fe42f58b2a5ea4c406b19c8cf672ed8ec0695", fullTransactions: true)
+            XCTAssertEqual(5184323, result.number)
+        } catch {
+            XCTFail()
+        }
+    }
+    
+    func testGetBlockByNumber1() throws {
+        let web3 = Web3.NodesmithMainnetWeb3(apiKey: API_KEY)
+        let result = try web3.eth.getBlockByNumber("latest", fullTransactions: true)
+        XCTAssertNotNil(result)
+    }
+    
+    func testGetBlockByNumber2() throws {
+        let web3 = Web3.NodesmithMainnetWeb3(apiKey: API_KEY)
+        let result = try web3.eth.getBlockByNumber(UInt64(7140801), fullTransactions: false)
+        XCTAssertEqual(72, result.transactions.count)
+    }
+    
+    func testGetBlockByNumber_ExpectedError() {
+        do {
+            let web3 = Web3.NodesmithMainnetWeb3(apiKey: API_KEY)
+            let _ = try web3.eth.getBlockByNumber(UInt64(424242424242), fullTransactions: true)
+            XCTFail() // Fail if we got here
+        } catch {
+            
+        }
+    }
+    
+    func testGetTransactionByHash() throws {
+        let web3 = Web3.NodesmithMainnetWeb3(apiKey: API_KEY)
+        let result = try web3.eth.getTransactionDetails("0x98ca2f92879b33e56b72f2b2cf250fe38e742f5dd4bea1da958da78d5985f3c0")
+        XCTAssertNotNil(result)
+        let amountString = Web3.Utils.formatToEthereumUnits(result.transaction.value, toUnits: .eth, decimals: 3)
+        XCTAssertEqual("0.002", amountString)
+        
+    }
+    
+    func testGasPrice() throws {
+        let web3 = Web3.NodesmithMainnetWeb3(apiKey: API_KEY)
+        let response = try web3.eth.getGasPrice()
+        XCTAssertNotNil(response)
+        XCTAssertTrue(response > 0)
+    }
+}


### PR DESCRIPTION
This change adds named support for the new [goerli testnet[(https://goerli.net/) by adding it to the Networks enum. It also adds a new `NodesmithProvider` to make connecting to that service easier. [Nodesmith](https://nodesmith.io) is a service which provides free JSON RPC endpoints for interacting with Ethereum networks.