### PR TITLE
Expose BIP39 words and separator

### DIFF
--- a/Sources/web3swift/KeystoreManager/BIP39.swift
+++ b/Sources/web3swift/KeystoreManager/BIP39.swift
@@ -16,7 +16,7 @@ public enum BIP39Language {
     case french
     case italian
     case spanish
-    var words: [String] {
+    public var words: [String] {
         switch self {
         case .english:
             return englishWords
@@ -36,7 +36,7 @@ public enum BIP39Language {
             return spanishWords
         }
     }
-    var separator: String {
+    public var separator: String {
         switch self {
         case .japanese:
             return "\u{3000}"


### PR DESCRIPTION
Exposing the list of words will make it easier for an application to implement advanced mnemonic phrase validation and word completion.