### PR TITLE
Update ens registry contract address

### DIFF
--- a/Sources/web3swift/Utils/ENS/ENSRegistry.swift
+++ b/Sources/web3swift/Utils/ENS/ENSRegistry.swift
@@ -17,23 +17,7 @@ public extension ENS {
         
         public init?(web3: web3) {
             self.web3 = web3
-            switch web3.provider.network {
-            case .Mainnet?:
-                registryContractAddress = EthereumAddress("0x314159265dd8dbb310642f98f50c066173c1259b")
-            case .Rinkeby?:
-                registryContractAddress = EthereumAddress("0xe7410170f87102df0055eb195163a03b7f2bff4a")
-            case .Ropsten?:
-                registryContractAddress = EthereumAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010")
-            default:
-                let url = web3.provider.url.absoluteString
-                if url.contains("https://rpc.goerli.mudit.blog")
-                    || url.contains("http://goerli.blockscout.com")
-                    || url.contains("http://goerli.prylabs.net")
-                    || url.contains("https://rpc.slock.it/goerli") {
-                    registryContractAddress = EthereumAddress("0x112234455c3a32fd11230c42e7bccd4a84e02010")
-                }
-                return nil
-            }
+            registryContractAddress = EthereumAddress("0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e")
         }
         
         lazy var defaultOptions: TransactionOptions = {


### PR DESCRIPTION
The new contract is located at the same address on all networks.

Fixes #237 