### PR TITLE
[recreated] Detect read function aborting by messaged require statement

### DIFF
--- a/Sources/web3swift/EthereumABI/ABIElements.swift
+++ b/Sources/web3swift/EthereumABI/ABIElements.swift
@@ -175,6 +175,40 @@ extension ABI.Element {
         case .fallback(_):
             return nil
         case .function(let function):
+            // the response size greater than equal 100 bytes, when read function aborted by "require" statement.
+            // if "require" statement has no message argument, the response is empty (0 byte).
+            if( data.bytes.count >= 100 ){
+                let check00_31 = BigUInt( "08C379A000000000000000000000000000000000000000000000000000000000", radix:16 )!
+                let check32_63 = BigUInt( "0000002000000000000000000000000000000000000000000000000000000000", radix:16 )!
+
+                // check data[00-31] and data[32-63]
+                if check00_31 == BigUInt( data[0...31] ) && check32_63 == BigUInt( data[32...63] ) {
+                    // data.bytes[64-67] contains the length of require message
+                    let len = (Int(data.bytes[64])<<24) | (Int(data.bytes[65])<<16) | (Int(data.bytes[66])<<8) | Int(data.bytes[67])
+
+                    let message = String( bytes:data.bytes[68..<(68+len)], encoding:.utf8 )!
+
+                    print( "read function aborted by require statement: \(message)" )
+
+                    var returnArray = [String:Any]()
+
+                    // set infomation
+                    returnArray["_abortedByRequire"] = true
+                    returnArray["_errorMessageFromRequire"] = message
+
+                    // set empty values
+                    for i in 0 ..< function.outputs.count {
+                        let name = "\(i)"
+                        returnArray[name] = function.outputs[i].type.emptyValue
+                        if function.outputs[i].name != "" {
+                            returnArray[function.outputs[i].name] = function.outputs[i].type.emptyValue
+                        }
+                    }
+
+                    return returnArray
+                }
+            }
+            // the "require" statement with no message argument will be caught here
             if (data.count == 0 && function.outputs.count == 1) {
                 let name = "0"
                 let value = function.outputs[0].type.emptyValue
@@ -198,6 +232,8 @@ extension ABI.Element {
                 }
                 i = i + 1
             }
+            // set a flag to detect the request succeeded
+            returnArray["_success"] = true
             return returnArray
         }
     }


### PR DESCRIPTION
*[Reposted because the repository was recreated]*

Dear all:

If a require statement with a message aborts the reading function, an unexpected value may be returned as a response.

For example, if you call the following function,

```solidity
function testC3( uint val ) public pure returns( uint256 ){
  require( val != 0, "aborted by testC3" );

  return( 0 );
}
```

The following response will be returned.

> // Succeeded: testC3( 1 )
> ["0": 0]
> 
> // aborted: testC3( 0 )
> ["0": 3963877391197344453575983046348115674221700746820753546331534351508065746944]

If the reading function is aborted by a require statement that has a message, it seems that the data with the following configuration will be returned.(By the way, if there is no message specified in the require statement, [0] bytes will be returned as a response, so require could not be detected.)

> byte[00-31]: 08C379A000000000000000000000000000000000000000000000000000000000
> byte[32-63]: 0000002000000000000000000000000000000000000000000000000000000000
> byte[64-67]: length of require message
> byte[68-(68+length)]: require message body

Since it is helpful to know whether the reading function was aborted by require statement, I made a simple correction and sent the pull request.
please confirm.

If you call the above sample function with the modified code, empty data will be returned with the following log

> // Aborted: testC3( 0 )
> read function aborted by require statement: aborted by testC3
> ["0": 0, "_abortedByRequire": true, "_errorMessageFromRequire": "aborted by testC3"]

Also, I have confirmed the operation by checking the operation with the following contract.

```solidity
pragma solidity >= 0.5.0 < 0.7.0;

contract HelloWorld {
    //-----------------------------
    // test A
    //-----------------------------
    function testA1( uint val ) public pure{
      require( val != 0 );      // no message
    }

    function testA2( uint val ) public pure{
      require( val != 0, "" );  // empty string
    }

    function testA3( uint val ) public pure{
      require( val != 0, "aboreted by testA3" );
    }

    //-----------------------------
    // test B
    //-----------------------------
    function testB1( uint val ) public pure returns( string memory ){
      require( val != 0 );      // no message

      return( "hello, world" );
    }

    function testB2( uint val ) public pure returns( string memory ){
      require( val != 0, "" );  // empty string

      return( "hello, world" );
    }

    function testB3( uint val ) public pure returns( string memory ){
      require( val != 0, "aborted by testB3" );

      return( "hello, world" );
    }

    //-----------------------------
    // test C
    //-----------------------------
    function testC1( uint val ) public pure returns( uint256 ){
      require( val != 0 );      // no message

      return( 0 );
    }

    function testC2( uint val ) public pure returns( uint256 ){
      require( val != 0, "" );  // empty string

      return( 0 );
    }

    function testC3( uint val ) public pure returns( uint256 ){
      require( val != 0, "aborted by testC3" );

      return( 0 );
    }

    //-----------------------------
    // test D
    //-----------------------------
    function testD1( uint val ) public pure returns( uint256[5] memory ){
      require( val != 0 );      // no message

      uint256[5] memory temp;
      return( temp );
    }

    function testD2( uint val ) public pure returns( uint256[5] memory ){
      require( val != 0, "" );  // empty string

      uint256[5] memory temp;
      return( temp );
    }

    function testD3( uint val ) public pure returns( uint256[5] memory ){
      require( val != 0, "aborted by testD3" );

      uint256[5] memory temp;
      return( temp );
    }

    function testD4( uint val ) public pure returns( uint256[5] memory ){
      require( val != 0, "long message from testD4, abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789.abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789.abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789.abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789.abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789.abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789.abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789.abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789.abcdefghijklmnopqrstuvwxyz, ABCDEFGHIJKLMNOPQRSTUVWXYZ, 0123456789." );

      uint256[5] memory temp;
      return( temp );
    }
}
```

Then, thank you for the above.