### PR TITLE
Move away from secp256k1 as source

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/attaswift/BigInt.git",
         "state": {
           "branch": null,
-          "revision": "108801d539eb014469c758bc0d7f734690791fb4",
-          "version": "4.0.0"
+          "revision": "889a1ecacd73ccc189c5cb29288048f186c44ed9",
+          "version": "5.2.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,8 @@
         "repositoryURL": "https://github.com/attaswift/BigInt.git",
         "state": {
           "branch": null,
-          "revision": "018a5925f60f9e0523edd261de394a0898fe95b7",
-          "version": "3.1.0"
-        }
-      },
-      {
-        "package": "Cryptor",
-        "repositoryURL": "https://github.com/v57/BlueCryptor.git",
-        "state": {
-          "branch": null,
-          "revision": "62470ce23835f8920ce58e39d59548406af85dea",
-          "version": "1.0.23"
+          "revision": "108801d539eb014469c758bc0d7f734690791fb4",
+          "version": "4.0.0"
         }
       },
       {
@@ -24,8 +15,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "874280173e082cdd7ac6602be235914efe3f4dbc",
-          "version": "0.13.0"
+          "revision": "3a2acbb32ab68215ee1596ee6004da8e90c3721b",
+          "version": "1.0.0"
         }
       },
       {
@@ -33,17 +24,35 @@
         "repositoryURL": "https://github.com/mxcl/PromiseKit.git",
         "state": {
           "branch": null,
-          "revision": "66bcc386163121f14ee543aa20b682973cc98dd7",
-          "version": "6.5.2"
+          "revision": "aea48ea1855f5d82e2dffa6027afce3aab8f3dd7",
+          "version": "6.13.3"
         }
       },
       {
-        "package": "SipHash",
-        "repositoryURL": "https://github.com/attaswift/SipHash",
+        "package": "secp256k1",
+        "repositoryURL": "https://github.com/Boilertalk/secp256k1.swift.git",
         "state": {
           "branch": null,
-          "revision": "e325083424688055363bbfcb7f1a440d7d7a1bae",
-          "version": "1.2.2"
+          "revision": "823281fe9def21b384099b72a9a53ca988317b20",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "package": "Starscream",
+        "repositoryURL": "https://github.com/daltoniam/Starscream.git",
+        "state": {
+          "branch": null,
+          "revision": "e6b65c6d9077ea48b4a7bdda8994a1d3c6969c8d",
+          "version": "3.1.1"
+        }
+      },
+      {
+        "package": "swift-nio-zlib-support",
+        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
+        "state": {
+          "branch": null,
+          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
+          "version": "1.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,15 +10,16 @@ let package = Package(
     .library(name: "web3swift", targets: ["web3swift"]),
     ],
   dependencies: [
-    .package(url: "https://github.com/attaswift/BigInt.git", from: "5.0.0"),
+    .package(url: "https://github.com/attaswift/BigInt.git", .exact("4.0.0")),
     .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.8.4"),
     .package(url: "https://github.com/daltoniam/Starscream.git", from: "3.1.0"),
-    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.0.0"),
+    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("1.0.0")),
+    .package(url: "https://github.com/Boilertalk/secp256k1.swift.git", .exact("0.1.4")),
     ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.
     // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-    .target(name: "secp256k1"),
+//    .target(name: "secp256k1"),
     .target(
       name: "web3swift",
       dependencies: ["BigInt", "secp256k1", "PromiseKit", "Starscream", "CryptoSwift"],

--- a/Package.swift
+++ b/Package.swift
@@ -10,10 +10,10 @@ let package = Package(
     .library(name: "web3swift", targets: ["web3swift"]),
     ],
   dependencies: [
-    .package(url: "https://github.com/attaswift/BigInt.git", .exact("4.0.0")),
+    .package(url: "https://github.com/attaswift/BigInt.git", from: "5.0.0"),
     .package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.8.4"),
     .package(url: "https://github.com/daltoniam/Starscream.git", from: "3.1.0"),
-    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("1.0.0")),
+    .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.0.0"),
     .package(url: "https://github.com/Boilertalk/secp256k1.swift.git", .exact("0.1.4")),
     ],
   targets: [

--- a/web3swift.podspec
+++ b/web3swift.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |spec|
     spec.swift_version = '5.0'
     spec.frameworks = 'CoreImage'
     spec.dependency 'PromiseKit', '~> 6.8.4'
-    spec.dependency 'BigInt', '~> 4.0'
+    spec.dependency 'BigInt', '~> 5.0.0'
     spec.dependency 'Starscream', '~> 3.1.0'
     spec.dependency 'CryptoSwift', '~> 1.0.0'
-    spec.dependency 'secp256k1.c', '~> 0.1'
+    spec.dependency 'secp256k1.swift', '~> 0.1.4'
 end


### PR DESCRIPTION
I'm getting issues with my application because I use sepc256k1 and this repo builds its own version of secp256k1. I found that if I pin secp256k1 to v0.1.4 

Also in the PR, is pinning the following.

- move secp256k1 to dependencies
- pin BigInt to 4.0.0
- pin Cryptoswift to 1.0.0